### PR TITLE
Install Juju through snap

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,18 +1,16 @@
-includes: ['layer:basic', 'layer:apt']
+includes: ['layer:basic', 'layer:apt', 'layer:snap']
 options:
   apt:
     packages:
-      - 'juju'
-      - 'juju-core'
-      - 'juju-deployer'
       - 'git'
       - 'python-yaml'
       - 'python-jujuclient'
-      - 'charm-tools'
-  basic:
-    packages:
       - "python-pip"
       - "tree"
       - "python-dev"
       - "unzip"
       - "make"
+  snap:
+    juju:
+      channel: stable
+      classic: true

--- a/reactive/juju2-client.py
+++ b/reactive/juju2-client.py
@@ -33,8 +33,10 @@ HOME = expanduser('~{}'.format(USER))
 
 
 @when_not('juju.installed')
-@when('apt.installed.juju')
+@when('apt.installed.make')
 def set_juju_installed_state():
+    # Allows the use of the juju cli command in new sessions
+    check_call(['ln', '-s', '/snap/bin/juju', '/usr/bin/juju'])
     # Run juju once to generate initial config
     check_call([
         'su', USER, '-c',


### PR DESCRIPTION
Using the snap layer to install JuJu, since apt-get packages are behind current stable releases. Removed some unneeded apt-packages. Creates a symlink so in the cli the `juju` command still works.